### PR TITLE
added backlight handling on/off for lilygo-t-s3

### DIFF
--- a/src/screen/screen.cpp
+++ b/src/screen/screen.cpp
@@ -67,6 +67,11 @@ void screen_toggle()
 {
   screen_enabled = !screen_enabled;
   tft.writecommand(screen_enabled ? TFT_DISPON : TFT_DISPOFF);
+  // add backlight handling for Lilygo T-S3
+  // https://github.com/Bodmer/TFT_eSPI/discussions/2328
+  #if defined(LILYGO_T_S3)
+  digitalWrite(38, screen_enabled ? HIGH : LOW);
+  #endif
 }
 
 #if defined(ESP32)


### PR DESCRIPTION
Add support for backlight handling for Lilygo-T-S3, in this way when we power off the screen we reduce the power consumption avoiding the backlight to stay on